### PR TITLE
Avocado QEMU: remove duplicate PortTracker implementation

### DIFF
--- a/tests/avocado/README.rst
+++ b/tests/avocado/README.rst
@@ -6,7 +6,7 @@ Framework. To install Avocado, follow the instructions from this link::
 Tests here are written keeping the minimum amount of dependencies. To
 run the tests, you need the Avocado core package (`python-avocado` on
 Fedora, `avocado-framework` on pip). Extra dependencies should be
-documented in this file.
+documented in this file.  The current minimum required version is 54.0.
 
 In this directory, an ``avocado_qemu`` package is provided, containing
 the ``test`` module, which inherits from ``avocado.Test`` and provides


### PR DESCRIPTION
The PortTracker class was introduced on Avocado's own utility
libraries, starting with version 54.0, and it actually received fixes
after that.

Let's avoid this duplicate implementation and rely on the standard
one.

Signed-off-by: Cleber Rosa <crosa@redhat.com>