### PR TITLE
[RFC] make avocado-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,16 @@ endif
 .git-submodule-status: git-submodule-update config-host.mak
 
 # Rules related to Avocado bootstrap start here
-.PHONY: pip avocado
+.PHONY: pip avocado avocado-tests
 
 pip:
 	$(PYTHON) -m pip --version 2>/dev/null || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s --user' % (sys.executable, f))"
 
 avocado: pip
 	$(PYTHON) -m pip install --user avocado-framework avocado-framework-plugin-varianter-yaml-to-mux aexpect
+
+avocado-tests: avocado
+	avocado run tests/avocado
 
 # Check that we're not trying to do an out-of-tree build from
 # a tree that's been used for an in-tree build.

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,13 @@ endif
 .git-submodule-status: git-submodule-update config-host.mak
 
 # Rules related to Avocado bootstrap start here
-.PHONY: pip
+.PHONY: pip avocado
 
 pip:
 	$(PYTHON) -m pip --version 2>/dev/null || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s --user' % (sys.executable, f))"
+
+avocado: pip
+	$(PYTHON) -m pip install --user avocado-framework avocado-framework-plugin-varianter-yaml-to-mux aexpect
 
 # Check that we're not trying to do an out-of-tree build from
 # a tree that's been used for an in-tree build.
@@ -591,6 +594,7 @@ clean:
 	rm -f $$d/qemu-options.def; \
         done
 	rm -f $(SUBDIR_DEVICES_MAK) config-all-devices.mak
+	- pip uninstall -y avocado-framework avocado-framework-plugin-varianter-yaml-to-mux aexpect
 	- pip uninstall -y pip
 
 VERSION ?= $(shell cat VERSION)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ endif
 
 .git-submodule-status: git-submodule-update config-host.mak
 
+# Rules related to Avocado bootstrap start here
+.PHONY: pip
+
+pip:
+	$(PYTHON) -m pip --version 2>/dev/null || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s --user' % (sys.executable, f))"
+
 # Check that we're not trying to do an out-of-tree build from
 # a tree that's been used for an in-tree build.
 ifneq ($(realpath $(SRC_PATH)),$(realpath .))
@@ -585,6 +591,7 @@ clean:
 	rm -f $$d/qemu-options.def; \
         done
 	rm -f $(SUBDIR_DEVICES_MAK) config-all-devices.mak
+	- pip uninstall -y pip
 
 VERSION ?= $(shell cat VERSION)
 


### PR DESCRIPTION
This is an experiment with an integration that allows developers to simply run on a QEMU tree:

```
make avocado-tests
```

The result on a fresh environment is similar to this:

```
 make avocado-tests 
        CHK version_gen.h
         LEX convert-dtsv0-lexer.lex.c
make[1]: flex: Command not found
         BISON dtc-parser.tab.c
make[1]: bison: Command not found
         LEX dtc-lexer.lex.c
make[1]: flex: Command not found
make[1]: '/home/cleber/src/qemu/capstone/libcapstone.a' is up to date.
python -B -m pip --version 2>/dev/null || python -B -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s --user' % (sys.executable, f))"
pip 9.0.1 from /home/cleber/.local/lib/python2.7/site-packages (python 2.7)
python -B -m pip install --user avocado-framework avocado-framework-plugin-varianter-yaml-to-mux aexpect
Requirement already satisfied: avocado-framework in /home/cleber/.local/lib/python2.7/site-packages
Requirement already satisfied: avocado-framework-plugin-varianter-yaml-to-mux in /home/cleber/.local/lib/python2.7/site-packages
Requirement already satisfied: aexpect in /home/cleber/.local/lib/python2.7/site-packages
Requirement already satisfied: stevedore>=0.14 in /home/cleber/.local/lib/python2.7/site-packages (from avocado-framework)
Requirement already satisfied: PyYAML in /home/cleber/.local/lib/python2.7/site-packages (from avocado-framework-plugin-varianter-yaml-to-mux)
Requirement already satisfied: six>=1.10.0 in /home/cleber/.local/lib/python2.7/site-packages (from stevedore>=0.14->avocado-framework)
Requirement already satisfied: pbr!=2.1.0,>=2.0.0 in /home/cleber/.local/lib/python2.7/site-packages (from stevedore>=0.14->avocado-framework)
avocado run tests/avocado
JOB ID     : cdd4883ba0881b673d44632cc3b9339bce9a751e
JOB LOG    : /home/cleber/avocado/job-results/job-2018-01-09T21.22-cdd4883/job.log
 (1/5) tests/avocado/test_info_memdev_host_nodes.py:TestInfoMemdev.test_hotplug_memory_default_policy: PASS (0.06 s)
 (2/5) tests/avocado/test_info_memdev_host_nodes.py:TestInfoMemdev.test_hotplug_memory_bind_policy: PASS (0.06 s)
 (3/5) tests/avocado/test_nec-usb-xhci.py:TestNecUsbXhci.test_available_after_migration: PASS (38.16 s)
 (4/5) tests/avocado/test_numa_hotplug.py:TestNumaHotplug.test_hotplug_mem_into_node: PASS (41.51 s)
 (5/5) tests/avocado/test_ovmf_with_240_vcpus.py:TestOvmfVcpus.test_run_vm: PASS (4.95 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 85.23 s
```
  
And after `make clean` we get:

```
...
make[1]: Leaving directory '/home/cleber/src/qemu/pc-bios/optionrom'
rm -f  aarch64-softmmu/config-devices.mak  alpha-softmmu/config-devices.mak  arm-softmmu/config-devices.mak  cris-softmmu/config-devices.mak  i386-softmmu/config-devices.mak  lm32-softmmu/config-devices.mak  m68k-softmmu/config-devices.mak  microblazeel-softmmu/config-devices.mak  microblaze-softmmu/config-devices.mak  mips64el-softmmu/config-devices.mak  mips64-softmmu/config-devices.mak  mipsel-softmmu/config-devices.mak  mips-softmmu/config-devices.mak  moxie-softmmu/config-devices.mak  nios2-softmmu/config-devices.mak  or1k-softmmu/config-devices.mak  ppc64-softmmu/config-devices.mak  ppcemb-softmmu/config-devices.mak  ppc-softmmu/config-devices.mak  s390x-softmmu/config-devices.mak  sh4eb-softmmu/config-devices.mak  sh4-softmmu/config-devices.mak  sparc64-softmmu/config-devices.mak  sparc-softmmu/config-devices.mak  tricore-softmmu/config-devices.mak  unicore32-softmmu/config-devices.mak  x86_64-softmmu/config-devices.mak  xtensaeb-softmmu/config-devices.mak  xtensa-softmmu/config-devices.mak  aarch64-linux-user/config-devices.mak  alpha-linux-user/config-devices.mak  armeb-linux-user/config-devices.mak  arm-linux-user/config-devices.mak  cris-linux-user/config-devices.mak  hppa-linux-user/config-devices.mak  i386-linux-user/config-devices.mak  m68k-linux-user/config-devices.mak  microblazeel-linux-user/config-devices.mak  microblaze-linux-user/config-devices.mak  mips64el-linux-user/config-devices.mak  mips64-linux-user/config-devices.mak  mipsel-linux-user/config-devices.mak  mips-linux-user/config-devices.mak  mipsn32el-linux-user/config-devices.mak  mipsn32-linux-user/config-devices.mak  nios2-linux-user/config-devices.mak  or1k-linux-user/config-devices.mak  ppc64abi32-linux-user/config-devices.mak  ppc64le-linux-user/config-devices.mak  ppc64-linux-user/config-devices.mak  ppc-linux-user/config-devices.mak  s390x-linux-user/config-devices.mak  sh4eb-linux-user/config-devices.mak  sh4-linux-user/config-devices.mak  sparc32plus-linux-user/config-devices.mak  sparc64-linux-user/config-devices.mak  sparc-linux-user/config-devices.mak  tilegx-linux-user/config-devices.mak  x86_64-linux-user/config-devices.mak config-all-devices.mak
pip uninstall -y avocado-framework avocado-framework-plugin-varianter-yaml-to-mux aexpect
Uninstalling avocado-framework-57.0:
  Successfully uninstalled avocado-framework-57.0
Uninstalling avocado-framework-plugin-varianter-yaml-to-mux-57.0:
  Successfully uninstalled avocado-framework-plugin-varianter-yaml-to-mux-57.0
Uninstalling aexpect-1.4.0:
  Successfully uninstalled aexpect-1.4.0
pip uninstall -y pip
Uninstalling pip-9.0.1:
  Successfully uninstalled pip-9.0.1
```

This shows the cleanup status:

```
[cleber@localhost qemu]$ which avocado
/usr/bin/which: no avocado in (/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/cleber/.local/bin:/home/cleber/bin)
```